### PR TITLE
프론트엔드 작업물의 결과를 확인하기 용이하게, DEVTOOLS 의존성 주입함

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,6 +12,11 @@ configurations {
 	compileOnly {
 		extendsFrom annotationProcessor
 	}
+	/* DevTool 의존성 주입을 위해 */
+	developmentOnly
+	runtimeClasspath {
+		extendsFrom developmentOnly
+	}
 }
 
 repositories {
@@ -27,6 +32,9 @@ dependencies {
 
 	/* firebase 개발 환경 설정*/
 	implementation 'com.google.firebase:firebase-admin:7.1.1'
+
+	/* DevTool 의존성 주입*/
+	developmentOnly("org.springframework.boot:spring-boot-devtools")
 
 	/* JUnit 5 의존성 주입하기 */
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,8 @@
+# 자동재시작 사용여부
+spring.devtools.restart.enabled=true
+
+# classpath 감지 주기 설정(선택사항)
+# poll-interval 값은 항상 quiet-period 보다 커야한다.
+# spring.devtools.restart.poll-interval=2s
+# spring.devtools.restart.quiet-period=1s
 


### PR DESCRIPTION
### 작업 내용 
---

프론트엔드 작업을 용이하게 하기 위해, `DevTools` 의존성 추가

#### 1. `build.gradle` 에서 수정함

   ```
   configurations {
   
   	/* DevTool 의존성 주입을 위해 */
   	developmentOnly
   	runtimeClasspath {
   		extendsFrom developmentOnly
   	}
   }
   dependencies {
   	/* DevTool 의존성 주입*/
   	developmentOnly("org.springframework.boot:spring-boot-devtools")
   }
   ```

  
#### 2. `ctrl/command+shift+A` 입력

   Registry 검색

   `compiler.automake.allow.when.app.running 항목의 체크박스를 체크하여 활성화시킴
![2](https://user-images.githubusercontent.com/54317409/117538483-59bf3c80-b041-11eb-92c1-ae8e7793d2c6.JPG)


   

####  3. `ctrl+alt + s` 눌러서 file > settings 화면 띄운다

   `Build, Execution, Deployment` > Compiler 선택하여 아래의 화면을 확인한다. 

   그 다음  `Build project Automatically` 를 클릭하여 활성화 시킴

![1](https://user-images.githubusercontent.com/54317409/117538508-81aea000-b041-11eb-9637-db380c624783.JPG)



