### PR TITLE
질문상세페이지 조회 구현 및 간단한 프론트엔드 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,10 +35,10 @@ dependencies {
 
 	/* DevTool 의존성 주입*/
 	developmentOnly("org.springframework.boot:spring-boot-devtools")
-
-	/* JUnit 5 의존성 주입하기 */
+	/* JUnit 5 */
+	testImplementation('org.springframework.boot:spring-boot-starter-test') //
 }
-
+/* JUnit 5 */
 test {
 	useJUnitPlatform()
 }

--- a/src/main/java/com/AkobotWeb/Query/InsertDummy.java
+++ b/src/main/java/com/AkobotWeb/Query/InsertDummy.java
@@ -1,0 +1,8 @@
+package com.AkobotWeb.Query;
+
+/**
+ * Dummy Data 를 insert하기 위한 클래스
+ * 2021-05-11 Junho Choi
+ */
+public class InsertDummy {
+}

--- a/src/main/java/com/AkobotWeb/controller/MainController.java
+++ b/src/main/java/com/AkobotWeb/controller/MainController.java
@@ -11,6 +11,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.RequestMapping;
 
 @Controller
@@ -34,7 +35,7 @@ public class MainController {
         return "home";
     }
 
-    /*TODO list페이지 작성*/
+    /* 질문 게시판 */
     @GetMapping("/tables")
     public String tables(BoardVO boardVO, Model model) throws Exception {
         /* log 이용하는 방식으로 변경할 것*/
@@ -43,11 +44,21 @@ public class MainController {
         return "tables";
     }
 
-    /*TODO 질문 question 페이지 작성*/
-    @GetMapping("/question")
+   /* 질문 question 페이지 작성 */
+    /* @GetMapping("/question")
     public String list() {
         return "questionDetail";
+    }*/
+    /* 0510 질문 상세 정보 조회*/
+    @GetMapping("/questionDetail")
+    public void read(long bno, Model model) throws Exception {
+        //TODO log
+        model.addAttribute("result", fbservice.read(bno));
     }
+
+
+
+
 
     /*TODO Login.html —> bootstrap에 있던 로그인 페이지(일단 그대로 따옴)*/
     @GetMapping("/login")

--- a/src/main/java/com/AkobotWeb/domain/BoardVO.java
+++ b/src/main/java/com/AkobotWeb/domain/BoardVO.java
@@ -11,7 +11,7 @@ import lombok.Data;
 
 @Data
 public class BoardVO {
-    private int bno;
+    private Long bno;
     private String content;
     private String name;
     private Timestamp regDate;

--- a/src/main/java/com/AkobotWeb/service/FirebaseService.java
+++ b/src/main/java/com/AkobotWeb/service/FirebaseService.java
@@ -16,6 +16,11 @@ public interface FirebaseService {
     /* 0503 게시판 테이블 가져오기 */
     public List<BoardVO> getBoardVO() throws Exception;
 
+    /* 0510 insert*/
+    public Long insert(BoardVO board) throws Exception;
+
+    /* 0510 questionDetails 질문 등록된 내용 가져옴*/
+    public BoardVO read(Long bno) throws Exception;
 
     /* 0504 테스트*/
 

--- a/src/main/java/com/AkobotWeb/service/FirebaseServiceImpl.java
+++ b/src/main/java/com/AkobotWeb/service/FirebaseServiceImpl.java
@@ -60,4 +60,35 @@ public class FirebaseServiceImpl implements FirebaseService {
 
         return list;
     }
+
+    /* TODO 0510 */
+    @Override
+    public Long insert(BoardVO board) throws Exception {
+
+
+        return 1L;
+    }
+
+    /* TODO 0510 */
+    @Override
+    public BoardVO read(Long bno) throws Exception {
+        firestore = FirestoreClient.getFirestore();
+        BoardVO boardVO;
+        // Create a reference to the collection
+        CollectionReference ref = firestore.collection(COLLECTION_NAME);
+
+        // Create a query against the collection.
+        Query query = ref.whereEqualTo("bno", bno);
+
+        // retrieve  query results asynchronously using query.get()
+        ApiFuture<QuerySnapshot> querySnapshot = query.get();
+        DocumentSnapshot document = querySnapshot.get().getDocuments().get(0); // 리스트의 0번쨰 요소를 가져오도록
+
+        boardVO = document.toObject(BoardVO.class);
+
+        /* TODO log */
+        /*System.out.println(boardVO.toString());*/
+
+        return boardVO;
+    }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -6,3 +6,4 @@ spring.devtools.restart.enabled=true
 # spring.devtools.restart.poll-interval=2s
 # spring.devtools.restart.quiet-period=1s
 
+# 로그 파일 위치 지정 및 로깅 레벨 설정

--- a/src/main/resources/templates/common_codes/fragments.html
+++ b/src/main/resources/templates/common_codes/fragments.html
@@ -42,12 +42,18 @@
     <script src="js/sb-admin-2.min.js"></script>
 
     <!-- Page level plugins -->
-    <script src=".vendor/chart.js/Chart.min.js"></script>
+    <script src="vendor/chart.js/Chart.min.js"></script>
 
     <!-- Page level custom scripts -->
-    <script src=".js/demo/chart-area-demo.js"></script>
+    <script src="js/demo/chart-area-demo.js"></script>
     <script src="js/demo/chart-pie-demo.js"></script>
 
+    <!-- Page level plugins -->
+    <script src="vendor/datatables/jquery.dataTables.min.js"></script>
+    <script src="vendor/datatables/dataTables.bootstrap4.min.js"></script>
+
+    <!-- Page level custom scripts -->
+    <script src="js/demo/datatables-demo.js"></script>
 </footer>
 </body>
 

--- a/src/main/resources/templates/questionDetail.html
+++ b/src/main/resources/templates/questionDetail.html
@@ -17,16 +17,8 @@
         <div id="content">
 
             <!-- Topbar -->
-            <nav class="navbar navbar-expand navbar-light bg-white topbar mb-4 static-top shadow">
-
-                <!-- Sidebar Toggle (Topbar) -->
-                <button id="sidebarToggleTop" class="btn btn-link d-md-none rounded-circle mr-3">
-                    <i class="fa fa-bars"></i>
-                </button>
-
-                <!-- Topbar Navbar -->
-                <th:block th:replace="~{/common_codes/topbar.html}"></th:block>
-                <!-- End of Topbar -->
+            <th:block th:replace="~{/common_codes/topbar.html}"></th:block>
+            <!-- End of Topbar -->
 
             <!-- Begin Page Content -->
             <div class="container-fluid">
@@ -43,11 +35,28 @@
                 <div class="card shadow mb-4">
                     <div class="card-header py-3">
                         <!-- 질문 끌어올것 -->
-                        <h6 class="m-0 font-weight-bold text-primary">yyyy-mm-dd hh-mm에 등록된 미해결 질문입니다</h6>
+                        <div class="form-group">
+                            <h6 class="m-0 font-weight-bold text-primary">질문 등록 시간</h6>
+                            <input type="text" class="form-control" name="regDate" th:value="${result.regDate}" readonly>
+                        </div>
+                        <!--<td th:text="${#temporals.format(result.regDate, 'yyyy-MM-dd HH:mm')}"></td>-->
+                        <!--<p th:text="${#temporals.formatISO(result.regDate)}"></p>-->
                     </div>
                     <div class="card-body">
-                        <!-- 질문 끌어올것 -->
-                        <p>질문: </p>
+                        <!-- TODO 질문 끌어올것 -->
+                        <div class="form-group">
+                            <label>게시글 번호</label>
+                            <input type="text" class="form-control" name="bno" th:value="${result.bno}" readonly>
+                        </div>
+                        <div class="form-group">
+                            <label>질문 내용</label>
+                            <input type="text" class="form-control" name="bno" th:value="${result.content}" readonly>
+                        </div>
+                        <div class="form-group">
+                            <label>질문 작성자</label>
+                            <input type="text" class="form-control" name="bno" th:value="${result.name}" readonly>
+                        </div>
+
                         <p>질문 끌어오기....</p>
                         <br><br><br>
                         <p class="mb-0">답변 등록:</p>
@@ -57,12 +66,10 @@
                                 <label for="Answer">Answer:</label><br />
                                 <textarea name="Answer" rows="15" cols="100" id="Answer"></textarea>
                                 <br>
-                                <input
-                                        type="submit"
-                                        name="submit"
-                                        value="등록"
-                                        class="submit-button"
-                                />
+                                <!-- TODO 추후 개선 -->
+                                <button type="submit" class="btn btn-outline-primary">등록</button>
+                                <button type="reset" class="btn btn-outline-secondary">리셋</button>
+                                <button type="button" class="btn btn-outline-success"><a style="text-decoration:none" href="/tables">취소</a></button>
                             </form>
                         </div>
                     </div>

--- a/src/main/resources/templates/tables.html
+++ b/src/main/resources/templates/tables.html
@@ -65,7 +65,7 @@
                                         <!-- TODO Thymeleaf 사용영역 -->
                                         <tr th:each="VO : ${result}">
                                             <td>[[${VO.bno}]]</td>
-                                            <td>[[${VO.content}]]</td>
+                                            <td><a th:href="@{/questionDetail(bno=${VO.bno})}">[[${VO.content}]]</a></td>
                                             <td>[[${VO.name}]]</td>
                                             <td>[[${VO.regDate}]]</td>
                                             <td>#</td>


### PR DESCRIPTION
### 1. 질문 상세 페이지 조회 구현
질문 게시판에 등록된 질문 게시글을 클릭하면 질문 상세 페이지로 이동하게 됨.
해당 페이지에서 `아코봇 관리자`는 미해결 질문에 대해 답변할 수 있고, 해당 내역을 전송하게 되면, 
아코봇이 학습하는 `Cloud Firestore`로 전송되어 학습할 수 있을 것으로 기대함 

(구현 방법 ) 게시판 번호 bno 를 파라미터로 `cloud firestore` DB의 주어진 `Collection`에서  해당 `Document` 를 찾고, POJO 방식으로 변환하여 리턴하면, 해당 객체를 model에 담아서 view에서 사용할 수 있게 됨. 
![성과](https://user-images.githubusercontent.com/54317409/117699107-65586200-b1ff-11eb-826f-9fefcdf6a281.JPG)

##### 개선해야할 점
   A. URL를 임의로 입력하여 <u>존재하지 않은 bno</u>를 입력할 때 오류 발생
   B. `cloud firestore`에서 bno를 찾을 때 bno 가 중복되면 여러 `document`를 자바 콜렉션프레임워크 List에 담게 되는 점
   C. 전송 버튼 누르고 난 후 아코봇 DB로 POST 방식으로 전송하는 `INSERT` 기능 구현을 위해 해당 데이터베이스 구조 논의 필요
 
### 2. 관련 페이지의 프론트 엔드 부를 수정함
.이 들어가 있어서 해당 자바스크립트를 못 읽던 것을 수정 
![수정내역1](https://user-images.githubusercontent.com/54317409/117699307-a6e90d00-b1ff-11eb-9f74-aff016e04642.JPG)

로그인 부분과 관련된 `topbar` 코드가 중복되어 있음을 수정
![수정내역2](https://user-images.githubusercontent.com/54317409/117699399-c8e28f80-b1ff-11eb-8916-09a07c545432.JPG)
 