### PR TITLE
더미데이터 1000건 생성 및 전체 조회 테스트

### DIFF
--- a/src/main/java/com/AkobotWeb/Query/Dummy/InsertDummy.java
+++ b/src/main/java/com/AkobotWeb/Query/Dummy/InsertDummy.java
@@ -1,0 +1,30 @@
+package com.AkobotWeb.Query.Dummy;
+
+import com.AkobotWeb.domain.BoardVO;
+import com.google.api.core.ApiFuture;
+import com.google.cloud.Timestamp;
+import com.google.cloud.firestore.DocumentReference;
+import com.google.cloud.firestore.Firestore;
+import com.google.firebase.cloud.FirestoreClient;
+import org.springframework.stereotype.Service;
+
+/**
+ * Dummy Data 를 insert하기 위한 클래스
+ * 2021-05-11 Junho Choi
+ */
+@Service
+public class InsertDummy  {
+    public static final String COLLECTION_NAME = "TBL_DUMMY"; // cloud firestore의 collection name
+
+    Firestore firestore;
+
+    public void insertDummy(){
+        firestore= FirestoreClient.getFirestore();
+        for(int i=1; i<1000; i++){
+            BoardVO boardVO = new BoardVO(Integer.toUnsignedLong(i),"dummy content","dummy",Timestamp.now());
+            ApiFuture<DocumentReference> future = firestore.collection(COLLECTION_NAME).add(boardVO);
+        }
+        System.out.println("Done");
+    }
+
+}

--- a/src/main/java/com/AkobotWeb/Query/InsertDummy.java
+++ b/src/main/java/com/AkobotWeb/Query/InsertDummy.java
@@ -1,8 +1,0 @@
-package com.AkobotWeb.Query;
-
-/**
- * Dummy Data 를 insert하기 위한 클래스
- * 2021-05-11 Junho Choi
- */
-public class InsertDummy {
-}

--- a/src/main/java/com/AkobotWeb/controller/MainController.java
+++ b/src/main/java/com/AkobotWeb/controller/MainController.java
@@ -31,7 +31,7 @@ public class MainController {
 
     /*일단은 /home 요청해서 view 읽도록 함 */
     @GetMapping("/home")
-    public String home(){
+    public String home() {
         return "home";
     }
 
@@ -44,7 +44,7 @@ public class MainController {
         return "tables";
     }
 
-   /* 질문 question 페이지 작성 */
+    /* 질문 question 페이지 작성 */
     /* @GetMapping("/question")
     public String list() {
         return "questionDetail";
@@ -57,18 +57,18 @@ public class MainController {
     }
 
 
-
-
-
-    /*TODO Login.html —> bootstrap에 있던 로그인 페이지(일단 그대로 따옴)*/
+    /* Login.html —> bootstrap에 있던 로그인 페이지(일단 그대로 따옴)*/
     @GetMapping("/login")
-    public String login(){
+    public String login() {
         return "login";
     }
-    /*TODO manual.html —> 아코봇 사용방법이 앞으로 등재될 페이지*/
+
+    /* manual.html —> 아코봇 사용방법이 앞으로 등재될 페이지*/
     @GetMapping("/manual")
-    public String manual(){
+    public String manual() {
         return "manual";
     }
+
+
 
 }

--- a/src/main/java/com/AkobotWeb/controller/RestController.java
+++ b/src/main/java/com/AkobotWeb/controller/RestController.java
@@ -27,5 +27,11 @@ public class RestController {
         return firebaseService.getMemberDetail(name);
     }
 
+    /* mk dummy */
+    /*@GetMapping("/mkDummy")
+    public void mkDummy() throws Exception {
+        firebaseService.mkDummy();
+    }*/
+
 
 }

--- a/src/main/java/com/AkobotWeb/domain/BoardVO.java
+++ b/src/main/java/com/AkobotWeb/domain/BoardVO.java
@@ -6,10 +6,14 @@ package com.AkobotWeb.domain;
  */
 
 import com.google.cloud.Timestamp;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 @Data
+@AllArgsConstructor
+@NoArgsConstructor
 public class BoardVO {
     private Long bno;
     private String content;

--- a/src/main/java/com/AkobotWeb/service/FirebaseService.java
+++ b/src/main/java/com/AkobotWeb/service/FirebaseService.java
@@ -22,6 +22,11 @@ public interface FirebaseService {
     /* 0510 questionDetails 질문 등록된 내용 가져옴*/
     public BoardVO read(Long bno) throws Exception;
 
-    /* 0504 테스트*/
+
+    /**
+     * 테스트 관련
+     * */
+    /* 0510 make Dummy Collections */
+    public void mkDummy() throws Exception;
 
 }

--- a/src/main/java/com/AkobotWeb/service/FirebaseServiceImpl.java
+++ b/src/main/java/com/AkobotWeb/service/FirebaseServiceImpl.java
@@ -2,6 +2,7 @@ package com.AkobotWeb.service;
 
 import com.AkobotWeb.domain.BoardVO;
 import com.google.api.core.ApiFuture;
+import com.google.cloud.Timestamp;
 import com.google.cloud.firestore.*;
 import com.google.firebase.cloud.FirestoreClient;
 import lombok.AllArgsConstructor;
@@ -18,7 +19,6 @@ public class FirebaseServiceImpl implements FirebaseService {
     public static final String COLLECTION_NAME = "TBL_BOARD"; // cloud firestore의 collection name
 
     Firestore firestore;
-    BoardVO boardVO = null;
 
     @Override
     public String add(BoardVO board) throws Exception {
@@ -42,7 +42,7 @@ public class FirebaseServiceImpl implements FirebaseService {
         }
     }
 
-    /* 0503 */
+    /* 0503 질문 게시글 전체 조회 기능 구현 */
     @Override
     public List<BoardVO> getBoardVO() throws Exception {
         /*System.out.println("getboard");*/
@@ -69,7 +69,7 @@ public class FirebaseServiceImpl implements FirebaseService {
         return 1L;
     }
 
-    /* TODO 0510 */
+    /* 0510 질문 상세 페이지 조회 구현 */
     @Override
     public BoardVO read(Long bno) throws Exception {
         firestore = FirestoreClient.getFirestore();
@@ -90,5 +90,16 @@ public class FirebaseServiceImpl implements FirebaseService {
         /*System.out.println(boardVO.toString());*/
 
         return boardVO;
+    }
+
+    /* 0510 mkDummy */
+    @Override
+    public void mkDummy(){
+        firestore= FirestoreClient.getFirestore();
+        for(int i=1; i<1000; i++){
+            BoardVO boardVO = new BoardVO(Integer.toUnsignedLong(i),"dummy content","dummy", Timestamp.now());
+            ApiFuture<DocumentReference> future = firestore.collection("TBL_DUMMY").add(boardVO);
+        }
+        System.out.println("Done");
     }
 }


### PR DESCRIPTION
### 1. 더미데이터를 위해 별도의 Cloud Firestore 에서 콜렉션을 생성  
해당 구현을 위해 별도의 코드를 작성함. url 요청을 보내서 스프링 Controller가 처리해야 실행 되는듯 하였음.
그냥 main 메소드에서 실행시킬 때, `FirebaseApp with name [DEFAULT] doesn't exist.` 오류가 발생하였음.
![더미테스트1](https://user-images.githubusercontent.com/54317409/117705664-48c02800-b207-11eb-8346-5a351d7f11f3.JPG)

### 2. 더미데이터 콜렉션을 전체 게시판 조회에 적용하여 과부화 테스트
해당 페이지 `tables.html`에 포함된 tables 관련 부트스트랩의 자바스크립트가 페이징 처리 및 기본적인 검색을 해주고 있어서 일단은 테스트가 만족스러움.
![더미데이터1000건](https://user-images.githubusercontent.com/54317409/117705864-8de45a00-b207-11eb-84c6-e2a94b9f99f7.JPG)

![더미](https://user-images.githubusercontent.com/54317409/117705989-b8ceae00-b207-11eb-9da8-4ce22888919b.JPG)



