### PR TITLE
스프링 시큐리티 + 구글 로그인 연동을 통한 로그인 처리

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@ build/
 ### FIREBASE KEY ###
 serviceAccountKey.json
 
+### GOOGLE LOGIN ###
+application-oauth.properties
+
 ### LOG ###
 LOG_DIR_IS_UNDEFINED
 

--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,11 @@ dependencies {
 	/* DevTool 의존성 주입*/
 	developmentOnly("org.springframework.boot:spring-boot-devtools")
 	/* JUnit 5 */
-	testImplementation('org.springframework.boot:spring-boot-starter-test') //
+	testImplementation('org.springframework.boot:spring-boot-starter-test')
+
+	/* security + oauth2 */
+	implementation 'org.springframework.boot:spring-boot-starter-security'
+	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 }
 /* JUnit 5 */
 test {

--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,12 @@ dependencies {
 	/* JUnit 5 */
 	testImplementation('org.springframework.boot:spring-boot-starter-test')
 
+	/* JPA */
+	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+
+	/* RDBMS */
+	implementation 'com.h2database:h2'
+
 	/* security + oauth2 */
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'

--- a/src/main/java/com/AkobotWeb/AkobotWebApplication.java
+++ b/src/main/java/com/AkobotWeb/AkobotWebApplication.java
@@ -2,7 +2,9 @@ package com.AkobotWeb;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing // JPA Auditing 어노테이션들을 모두 활성화 할 수 있도록 하는 어노테이션
 @SpringBootApplication
 public class AkobotWebApplication {
 

--- a/src/main/java/com/AkobotWeb/Query/Dummy/InsertDummy.java
+++ b/src/main/java/com/AkobotWeb/Query/Dummy/InsertDummy.java
@@ -21,7 +21,7 @@ public class InsertDummy  {
     public void insertDummy(){
         firestore= FirestoreClient.getFirestore();
         for(int i=1; i<1000; i++){
-            BoardVO boardVO = new BoardVO(Integer.toUnsignedLong(i),"dummy content","dummy",Timestamp.now());
+            BoardVO boardVO = new BoardVO(Integer.toUnsignedLong(i),"dummy content","dummy","010-0000-0000",Timestamp.now());
             ApiFuture<DocumentReference> future = firestore.collection(COLLECTION_NAME).add(boardVO);
         }
         System.out.println("Done");

--- a/src/main/java/com/AkobotWeb/config/WebConfig.java
+++ b/src/main/java/com/AkobotWeb/config/WebConfig.java
@@ -1,0 +1,26 @@
+package com.AkobotWeb.config;
+
+import com.AkobotWeb.config.auth.LoginUserArgumentResolver;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
+
+
+@RequiredArgsConstructor
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    private final LoginUserArgumentResolver loginUserArgumentResolver;
+
+    /*
+    * HandlerMethodArgumentResolver는 항상 WebMvcConfigurer 의 addArguementResolvers()를 통해 추가해야한다.
+    *
+    * */
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> argumentResolvers){
+        argumentResolvers.add(loginUserArgumentResolver);
+    }
+}

--- a/src/main/java/com/AkobotWeb/config/auth/CustomOAuth2UserService.java
+++ b/src/main/java/com/AkobotWeb/config/auth/CustomOAuth2UserService.java
@@ -1,0 +1,58 @@
+package com.AkobotWeb.config.auth;
+
+import com.AkobotWeb.config.auth.dto.SessionUser;
+import com.AkobotWeb.domain.User.User;
+import com.AkobotWeb.domain.User.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+
+import javax.servlet.http.HttpSession;
+import java.util.Collections;
+
+/**
+ * OAuthAttributes를 기반으로 가입 및 정보수정, 세션 저장 등의 기능을 수행
+ */
+@RequiredArgsConstructor
+@Service
+public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequest, OAuth2User> {
+    private final UserRepository userRepository;
+    private final HttpSession httpSession;
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+        OAuth2UserService<OAuth2UserRequest, OAuth2User> delegate = new DefaultOAuth2UserService();
+        OAuth2User oAuth2User = delegate.loadUser(userRequest);
+        // 현재 로그인 진행 중인 서비스를 구분하는 코드
+        String registrationId = userRequest
+                .getClientRegistration()
+                .getRegistrationId();
+        // oauth2 로그인 진행 시 키가 되는 필드값
+        String userNameAttributeName = userRequest.getClientRegistration()
+                .getProviderDetails()
+                .getUserInfoEndpoint()
+                .getUserNameAttributeName();
+        // OAuthAttributes: attribute를 담을 클래스 (개발자가 생성)
+        OAuthAttributes attributes = OAuthAttributes
+                .of(registrationId, userNameAttributeName, oAuth2User.getAttributes());
+        User user = saveOrUpdate(attributes);
+        // SessioUser: 세션에 사용자 정보를 저장하기 위한 DTO 클래스 (개발자가 생성)
+        httpSession.setAttribute("user", new SessionUser(user));
+        return new DefaultOAuth2User(
+                Collections.singleton(new SimpleGrantedAuthority(user.getRoleKey())),
+                attributes.getAttributes(),
+                attributes.getNameAttributeKey()
+        );
+    }
+    private User saveOrUpdate(OAuthAttributes attributes) {
+        User user = userRepository.findByEmail(attributes.getEmail())
+                .map(entity -> entity.update(attributes.getName(), attributes.getPicture()))
+                .orElse(attributes.toEntity());
+        return userRepository.save(user);
+    }
+}

--- a/src/main/java/com/AkobotWeb/config/auth/LoginUser.java
+++ b/src/main/java/com/AkobotWeb/config/auth/LoginUser.java
@@ -1,0 +1,11 @@
+package com.AkobotWeb.config.auth;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER) // 해당 어노테이션이 생성될 수 있는 위치를 선언함 메소드의 파라미터로 선언된 객체에서만 사용 가능
+@Retention(RetentionPolicy.RUNTIME)
+public @interface LoginUser { //해당 파일을 어노테이션 클래스로 지정
+}

--- a/src/main/java/com/AkobotWeb/config/auth/LoginUserArgumentResolver.java
+++ b/src/main/java/com/AkobotWeb/config/auth/LoginUserArgumentResolver.java
@@ -1,0 +1,39 @@
+package com.AkobotWeb.config.auth;
+
+import com.AkobotWeb.config.auth.dto.SessionUser;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+import javax.servlet.http.HttpSession;
+
+@RequiredArgsConstructor
+@Component
+public class LoginUserArgumentResolver implements HandlerMethodArgumentResolver {
+
+    private final HttpSession httpSession;
+
+    /* supportsParameter() 컨트롤러 메소드에서 특정 파라미터를 지원하는 지 판단,
+     * 파라미터에 @LoginUser 어노테이션이 있고, 파라미터 클래스 타입이 SessionUser.class 라면 true 리턴
+     * */
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        boolean isLoginUserAnnotation = parameter.getMethodAnnotation(LoginUser.class) != null;
+        boolean isUserClass = SessionUser.class.equals(parameter.getParameterType());
+
+        return isLoginUserAnnotation && isUserClass;
+    }
+
+    /*
+     * 파라미터에 전달할 객체를 생성
+     * 세션에서 객체를 가져옴
+     * */
+    @Override
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
+        return httpSession.getAttribute("user");
+    }
+}

--- a/src/main/java/com/AkobotWeb/config/auth/OAuthAttributes.java
+++ b/src/main/java/com/AkobotWeb/config/auth/OAuthAttributes.java
@@ -1,0 +1,54 @@
+package com.AkobotWeb.config.auth;
+
+import com.AkobotWeb.domain.User.Role;
+import com.AkobotWeb.domain.User.User;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.Map;
+
+/**
+ * 구글 로그인 이후 가져온 사용자의 이메일, 이름, 프로필 사진 주소를 저장하는 Data Transfer Object
+ */
+@Getter
+public class OAuthAttributes {
+    private Map<String, Object> attributes;
+    private String nameAttributeKey, name, email, picture;
+
+    @Builder
+    public OAuthAttributes(Map<String, Object> attributes,
+                           String nameAttributeKey,
+                           String name, String email, String picture) {
+        this.attributes = attributes;
+        this.nameAttributeKey = nameAttributeKey;
+        this.name = name;
+        this.email = email;
+        this.picture = picture;
+    }
+
+    public static OAuthAttributes of(String registrationId,
+                                     String userNameAttributeName,
+                                     Map<String, Object> attributes) {
+        return ofGoogle(userNameAttributeName, attributes);
+    }
+
+    public static OAuthAttributes ofGoogle(String userNameAttributeName,
+                                           Map<String, Object> attributes) {
+        return OAuthAttributes.builder()
+                .name((String) attributes.get("name"))
+                .email((String) attributes.get("email"))
+                .picture((String) attributes.get("picture"))
+                .attributes(attributes)
+                .nameAttributeKey(userNameAttributeName)
+                .build();
+    }
+
+    public User toEntity() {
+        return User.builder()
+                .name(name)
+                .email(email)
+                .picture(picture)
+                .role(Role.GUEST)
+                .build();
+    }
+}

--- a/src/main/java/com/AkobotWeb/config/auth/SecurityConfig.java
+++ b/src/main/java/com/AkobotWeb/config/auth/SecurityConfig.java
@@ -1,0 +1,32 @@
+package com.AkobotWeb.config.auth;
+
+
+import com.AkobotWeb.domain.User.Role;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+
+@RequiredArgsConstructor
+@EnableWebSecurity // Spring Security 설정들을 활성화 시킴
+public class SecurityConfig extends WebSecurityConfigurerAdapter {
+    private final CustomOAuth2UserService customOAuth2UserService;
+
+    @Override
+    protected void configure(HttpSecurity http) throws Exception {
+        http
+                .csrf().disable()
+                .headers().frameOptions().disable() // h2-console 화면 사용하기 위해
+                .and()
+                .authorizeRequests() // URL 별 권환 관리 설정
+                .antMatchers("/","/dongguk","/login","/ask" ,"/vendor/**","/css/**", "/img/**", "/js/**", "/h2/**", "/h2-console/**").permitAll()
+                .antMatchers("/api/v1/**").hasRole(Role.USER.name()) //andMatcher 권환 관리 대상을 지정하는 옵션 p181
+                .anyRequest().authenticated() // 설정값들 외 나머지 URL // 인증된 사용자들에게만 허용
+                .and()
+                .logout().logoutSuccessUrl("/") // 로그아웃 기능에 대한 진입점, 성공시 /주소로 이동
+                .and()
+                .oauth2Login().userInfoEndpoint().userService(customOAuth2UserService); // OAuth2 로그인 기능에 대한 진입점,
+                //OAuth2 로그인 성공 이후 사용자 정보를 가져올 떄의 설정등
+                //소셜 로그인 성공 후 후속 조치를 진행할 UserService 인터페이스의 구현체를 등록
+    }
+}

--- a/src/main/java/com/AkobotWeb/config/auth/dto/SessionUser.java
+++ b/src/main/java/com/AkobotWeb/config/auth/dto/SessionUser.java
@@ -1,0 +1,19 @@
+package com.AkobotWeb.config.auth.dto;
+
+import com.AkobotWeb.domain.User.User;
+import lombok.Getter;
+import java.io.Serializable;
+/**
+ * 세션에 저장하려면 직렬화를 해야 하는데
+ * User 엔티티는 추후 변경사항이 있을 수 있기 때문에
+ * 직렬화를 하기 위한 별도의 SessionUser 클래스 생성
+ */
+@Getter
+public class SessionUser implements Serializable {
+    private String name, email, picture; // 인증된 사용자 정보만을
+    public SessionUser(User user) {
+        this.name = user.getName();
+        this.email = user.getEmail();
+        this.picture = user.getPicture();
+    }
+}

--- a/src/main/java/com/AkobotWeb/controller/MainController.java
+++ b/src/main/java/com/AkobotWeb/controller/MainController.java
@@ -11,6 +11,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.RequestMapping;
 
 @Controller
@@ -79,5 +80,17 @@ public class MainController {
     public String dongguk(){
         return "dongguk";
     }
+
+    /* 사용자가 질문 등록*/
+    /*@PostMapping("/add")
+    public void add(BoardVO board) throws Exception {
+        fbservice.add(board);
+        *//*rttr.addFlashAttribute("bno" , board.getBno());*//*
+     *//*return "ask";*//*
+    }*/
+    /*@GetMapping("/add")
+    public String goback() throws Exception{
+        return "ask";
+    }*/
 
 }

--- a/src/main/java/com/AkobotWeb/controller/MainController.java
+++ b/src/main/java/com/AkobotWeb/controller/MainController.java
@@ -39,7 +39,9 @@ public class MainController {
         }
         return "index";
     }
-    /*public String index(Model model, @LoginUser SessionUser user) {
+    /*
+    *   중복코드 최소화 하는 방법이지만, NULL EXCEPTION 이 일어남..
+    public String index(Model model, @LoginUser SessionUser user) {
         // .............
         // 사용자 정보: 위의 @LoginUser 어노테이션으로 대체
         // SessionUser user = (SessionUser) httpSession.getAttribute("user");
@@ -61,6 +63,12 @@ public class MainController {
     /* 질문 게시판 */
     @GetMapping("/tables")
     public String tables(BoardVO boardVO, Model model) throws Exception {
+        /* 세션 정보 */
+        SessionUser user = (SessionUser) httpSession.getAttribute("user");
+        if(user != null){
+            model.addAttribute("userName",user.getName());
+            model.addAttribute("userImg",user.getPicture());
+        }
         /* log 이용하는 방식으로 변경할 것*/
         /*System.out.println(boardVO);*/
         model.addAttribute("result", fbservice.getBoardVO());
@@ -69,6 +77,11 @@ public class MainController {
     /* DB 관리 게시판*/
     @GetMapping("/manage")
     public String manage(BoardVO boardVO, Model model) throws Exception {
+        SessionUser user = (SessionUser) httpSession.getAttribute("user");
+        if(user != null){
+            model.addAttribute("userName",user.getName());
+            model.addAttribute("userImg",user.getPicture());
+        }
         /* log 이용하는 방식으로 변경할 것*/
         /*System.out.println(boardVO);*/
         /*model.addAttribute("result", fbservice.getBoardVO());*/
@@ -82,6 +95,11 @@ public class MainController {
     /* 0510 질문 상세 정보 조회*/
     @GetMapping("/questionDetail")
     public void read(long bno, Model model) throws Exception {
+        SessionUser user = (SessionUser) httpSession.getAttribute("user");
+        if(user != null){
+            model.addAttribute("userName",user.getName());
+            model.addAttribute("userImg",user.getPicture());
+        }
         //TODO log
         model.addAttribute("result", fbservice.read(bno));
     }
@@ -95,7 +113,12 @@ public class MainController {
 
     /* manual.html —> 아코봇 사용방법이 앞으로 등재될 페이지*/
     @GetMapping("/manual")
-    public String manual() {
+    public String manual(Model model) {
+        SessionUser user = (SessionUser) httpSession.getAttribute("user");
+        if(user != null){
+            model.addAttribute("userName",user.getName());
+            model.addAttribute("userImg",user.getPicture());
+        }
         return "manual";
     }
 

--- a/src/main/java/com/AkobotWeb/controller/MainController.java
+++ b/src/main/java/com/AkobotWeb/controller/MainController.java
@@ -5,8 +5,11 @@ package com.AkobotWeb.controller;
  *
  * */
 
+import com.AkobotWeb.config.auth.LoginUser;
+import com.AkobotWeb.config.auth.dto.SessionUser;
 import com.AkobotWeb.domain.BoardVO;
 import com.AkobotWeb.service.FirebaseService;
+import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
@@ -14,20 +17,40 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.RequestMapping;
 
+import javax.servlet.http.HttpSession;
+
+@RequiredArgsConstructor
 @Controller
 @RequestMapping("/*")
 public class MainController {
     /*TODO Service 작성 */
     @Autowired
     private FirebaseService fbservice;
+    private final HttpSession httpSession;
 
-    /*TODO home.html을 기본페이지? 관습적으로 index.html을 기본페이지로 하는데..*/
-    /* home.html 로그인 하기전 홈 화면(login 버튼 -> 클릭 시 login.html로 이동) */
-   /* @GetMapping("/")
-    public String home(){
-        return "home";
+
+    /* 로그인 전이라면 로그인하라하고, 로그인하면 구글 로그인 정보 보여줌 */
+    @GetMapping("/")
+    public String index(Model model){
+        SessionUser user = (SessionUser) httpSession.getAttribute("user");
+        if(user != null){
+            model.addAttribute("userName",user.getName());
+            model.addAttribute("userImg",user.getPicture());
+        }
+        return "index";
     }
-    *//* index.html..*/
+    /*public String index(Model model, @LoginUser SessionUser user) {
+        // .............
+        // 사용자 정보: 위의 @LoginUser 어노테이션으로 대체
+        // SessionUser user = (SessionUser) httpSession.getAttribute("user");
+        if(user != null) {
+            model.addAttribute("userName", user.getName());
+            model.addAttribute("userImg", user.getPicture());
+        }
+        return "index";
+    }*/
+
+    //* index.html..*/
 
     /*일단은 /home 요청해서 view 읽도록 함 */
     @GetMapping("/home")
@@ -43,7 +66,14 @@ public class MainController {
         model.addAttribute("result", fbservice.getBoardVO());
         return "tables";
     }
-
+    /* DB 관리 게시판*/
+    @GetMapping("/manage")
+    public String manage(BoardVO boardVO, Model model) throws Exception {
+        /* log 이용하는 방식으로 변경할 것*/
+        /*System.out.println(boardVO);*/
+        /*model.addAttribute("result", fbservice.getBoardVO());*/
+        return "manage";
+    }
     /* 질문 question 페이지 작성 */
     /* @GetMapping("/question")
     public String list() {
@@ -71,13 +101,13 @@ public class MainController {
 
     /* 아코봇에서 미해결 질문 등록하는 페이지*/
     @GetMapping("/ask")
-    public String ask(){
+    public String ask() {
         return "ask";
     }
 
     /* 아코봇을 띄워주는 가상 동국대 입학처 페이지 연결*/
     @GetMapping("/dongguk")
-    public String dongguk(){
+    public String dongguk() {
         return "dongguk";
     }
 

--- a/src/main/java/com/AkobotWeb/controller/RestController.java
+++ b/src/main/java/com/AkobotWeb/controller/RestController.java
@@ -4,7 +4,9 @@ import com.AkobotWeb.domain.BoardVO;
 import com.AkobotWeb.service.FirebaseService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
 import java.util.ArrayList;
 
@@ -17,11 +19,6 @@ public class RestController {
     @Autowired
     FirebaseService firebaseService;
 
-    @GetMapping("/add")
-    public String add(@RequestParam BoardVO board) throws Exception {
-        return firebaseService.add(board);
-    }
-
     @GetMapping("/getMemberDetail")
     public BoardVO getMemberDetail(@RequestParam String name) throws Exception {
         return firebaseService.getMemberDetail(name);
@@ -31,6 +28,14 @@ public class RestController {
     @GetMapping("/mkDummy")
     public void mkDummy() throws Exception {
         firebaseService.mkDummy();
+    }
+
+    /* 질문 사용자가 직접 등록*/
+    @PostMapping("/add")
+    public void add(BoardVO board) throws Exception {
+        firebaseService.add(board);
+        /*rttr.addFlashAttribute("bno" , board.getBno());*/
+        /*return "redirect:/ask";*/
     }
 
 

--- a/src/main/java/com/AkobotWeb/domain/BaseTimeEntity.java
+++ b/src/main/java/com/AkobotWeb/domain/BaseTimeEntity.java
@@ -1,0 +1,26 @@
+package com.AkobotWeb.domain;
+
+/**
+ * 0525 로그인 구현을 위해
+ */
+
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import javax.persistence.EntityListeners;
+import javax.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass // JPA Entity 클래스 들이 BaseTimeEntity 를 상속할 경우 필드들도 칼럼으로 인식하도록
+@EntityListeners(AuditingEntityListener.class) // Auditing 기능을 포함시킴
+public abstract class BaseTimeEntity {
+    @CreatedDate  //Entity가 생성되어 저장될 때 시간이 자동 저장됨
+    private LocalDateTime createdDate;
+
+    @LastModifiedDate // 조회한 Entity의 값을 변경할 때 시간이 자동 저장됨
+    private LocalDateTime modifiedDate;
+
+}

--- a/src/main/java/com/AkobotWeb/domain/BoardVO.java
+++ b/src/main/java/com/AkobotWeb/domain/BoardVO.java
@@ -18,5 +18,6 @@ public class BoardVO {
     private Long bno;
     private String content;
     private String name;
+    private String phone;
     private Timestamp regDate;
 }

--- a/src/main/java/com/AkobotWeb/domain/User/Role.java
+++ b/src/main/java/com/AkobotWeb/domain/User/Role.java
@@ -1,0 +1,17 @@
+package com.AkobotWeb.domain.User;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum Role {
+    /* 구글 로그인 연동 시 권한 관련 enum 클래스, 스프링 시큐리티에서 권한 코드에 항상 ROLE_이 앞에 있어야함 */
+    GUEST("ROLE_GUEST", "손님"),
+    USER("ROLE_USER", "일반 사용자"),
+    Admin("ROLE_ADMIN","관리자");
+
+    private final String key;
+    private final String title;
+
+}

--- a/src/main/java/com/AkobotWeb/domain/User/User.java
+++ b/src/main/java/com/AkobotWeb/domain/User/User.java
@@ -1,0 +1,42 @@
+package com.AkobotWeb.domain.User;
+
+
+import com.AkobotWeb.domain.BaseTimeEntity;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import javax.persistence.*;
+
+@Getter
+@NoArgsConstructor
+@Entity
+public class User extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    @Column(nullable = false)
+    private String name;
+    @Column(nullable = false)
+    private String email;
+    @Column
+    private String picture;
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Role role;  // Role: 직접 만드는 클래스
+    @Builder
+    public User(String name, String email, String picture, Role role) {
+        this.name = name;
+        this.email = email;
+        this.picture = picture;
+        this.role = role;
+    }
+    public User update(String name, String picture) {
+        this.name = name;
+        this.picture = picture;
+        return this;
+    }
+    public String getRoleKey() {
+        return this.role.getKey();
+    }
+}

--- a/src/main/java/com/AkobotWeb/domain/User/UserRepository.java
+++ b/src/main/java/com/AkobotWeb/domain/User/UserRepository.java
@@ -1,0 +1,14 @@
+package com.AkobotWeb.domain.User;
+
+/**
+ * User의 CRUD를 책임질 User Repository
+ */
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User,Long> {
+    Optional<User> findByEmail(String email); // container object which may or may not contain a non-null value
+
+}

--- a/src/main/java/com/AkobotWeb/service/FirebaseService.java
+++ b/src/main/java/com/AkobotWeb/service/FirebaseService.java
@@ -8,8 +8,6 @@ import java.util.List;
 
 public interface FirebaseService {
 
-    /*TODO 좀 더 정밀하게 */
-    public String add(BoardVO board) throws Exception;
 
     public BoardVO getMemberDetail(String id) throws Exception;
 
@@ -29,4 +27,6 @@ public interface FirebaseService {
     /* 0510 make Dummy Collections */
     public void mkDummy() throws Exception;
 
+    /*TODO 좀 더 정밀하게 */
+    public void add(BoardVO board) throws Exception;
 }

--- a/src/main/java/com/AkobotWeb/service/FirebaseServiceImpl.java
+++ b/src/main/java/com/AkobotWeb/service/FirebaseServiceImpl.java
@@ -7,6 +7,7 @@ import com.google.cloud.firestore.*;
 import com.google.firebase.cloud.FirestoreClient;
 import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.web.bind.annotation.ModelAttribute;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -19,13 +20,6 @@ public class FirebaseServiceImpl implements FirebaseService {
     public static final String COLLECTION_NAME = "TBL_ASK_DUMMY"; // cloud firestore의 collection name
 
     Firestore firestore;
-
-    @Override
-    public String add(BoardVO board) throws Exception {
-        firestore = FirestoreClient.getFirestore();
-        ApiFuture<com.google.cloud.firestore.WriteResult> apiFuture = firestore.collection(COLLECTION_NAME).document(board.getName()).set(board);
-        return apiFuture.get().getUpdateTime().toString();
-    }
 
     @Override
     public BoardVO getMemberDetail(String name) throws Exception {
@@ -97,9 +91,37 @@ public class FirebaseServiceImpl implements FirebaseService {
     public void mkDummy(){
         firestore= FirestoreClient.getFirestore();
         for(int i=1; i<=25; i++){
-            BoardVO boardVO = new BoardVO(Integer.toUnsignedLong(i),"dummy content","dummy", Timestamp.now());
+            BoardVO boardVO = new BoardVO(Integer.toUnsignedLong(i),"dummy content","dummy","010-0000-0000", Timestamp.now());
             ApiFuture<DocumentReference> future = firestore.collection(COLLECTION_NAME).add(boardVO);
         }
         System.out.println("Done");
+    }
+
+    @Override
+    public void add(@ModelAttribute BoardVO board) throws Exception {
+
+        /*firestore= FirestoreClient.getFirestore();
+        firestore.collection(COLLECTION_NAME).get(
+        CollectionReference ref = firestore.collection(COLLECTION_NAME);
+
+        //현재 db의 bno max값을 가져온다
+        Query query = ref.orderBy("bno", Query.Direction.DESCENDING).limit(0);
+
+        long bno = query;
+        // bno ++; 하고 새로운 BoardVO객체를 만들어서 전달한다.
+
+        firestore = FirestoreClient.getFirestore();
+        ApiFuture<WriteResult> apiFuture = firestore.collection(COLLECTION_NAME).document(board.getName()).set(board);
+        return apiFuture.get().getUpdateTime().toString();*/
+
+        //TODO 0520
+        System.out.println(board.toString());
+
+        board.setBno(28L);
+        board.setRegDate(Timestamp.now());
+
+        ApiFuture<DocumentReference> future = firestore.collection(COLLECTION_NAME).add(board);
+
+
     }
 }

--- a/src/main/resources/application-oauth.properties
+++ b/src/main/resources/application-oauth.properties
@@ -1,3 +1,0 @@
-spring.security.oauth2.client.registration.google.client-id=409426375557-pjbfv4cugeu2p6oioifutm03uoh496n9.apps.googleusercontent.com
-spring.security.oauth2.client.registration.google.client-secret=ET6Tjj9_fVxcZOHEKV3nf3Zz
-spring.security.oauth2.client.registration.google.scope=profile,email

--- a/src/main/resources/application-oauth.properties
+++ b/src/main/resources/application-oauth.properties
@@ -1,0 +1,3 @@
+spring.security.oauth2.client.registration.google.client-id=409426375557-pjbfv4cugeu2p6oioifutm03uoh496n9.apps.googleusercontent.com
+spring.security.oauth2.client.registration.google.client-secret=ET6Tjj9_fVxcZOHEKV3nf3Zz
+spring.security.oauth2.client.registration.google.scope=profile,email

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -10,3 +10,6 @@ spring.devtools.restart.enabled=true
 
 #application-oauth.properties 로딩
 spring.profiles.include=oauth
+
+#로컬 작업에서 db 작업을 위해 h2
+spring.h2.console.enabled=true

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -7,3 +7,6 @@ spring.devtools.restart.enabled=true
 # spring.devtools.restart.quiet-period=1s
 
 # 로그 파일 위치 지정 및 로깅 레벨 설정
+
+#application-oauth.properties 로딩
+spring.profiles.include=oauth

--- a/src/main/resources/templates/ask.html
+++ b/src/main/resources/templates/ask.html
@@ -3,124 +3,40 @@
 <head>
     <title>Akobot question form</title>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta http-equiv="X-UA-Compatible" content="ie=edge" />
     <link rel="stylesheet" type="text/css" href="css/style.css"/>
 </head>
-<style>
-    .wrapper {
-        display: flex;
-        justify-content: center;
-        align-items: center;
-        min-height: 170vh;
-        background: #301e4e;
-    }
-    .content {
-        font-family: system-ui, serif;
-        font-size: 1rem;
-        padding: 2rem;
-        border-radius: 2rem;
-        background: #ff6e6c;
-    }
-    button {
-        background-color: #F9B514;
-        padding: 5px 10px;
-        border-radius: 4px;
-        cursor: pointer;
-    }
 
-    .modal {
-        position: fixed;
-        top: 0;
-        left: 0;
-        width: 100%;
-        height: 100%;
-        display: flex;
-        justify-content: center;
-        align-items: center;
-    }
-
-    .modal .bg {
-        width: 100%;
-        height: 100%;
-        background-color: rgba(0, 0, 0, 0.6);
-    }
-
-    .modalBox {
-        position: absolute;
-        background-color: #fff;
-        width: 400px;
-        height: 200px;
-        padding: 15px;
-    }
-
-    .modalBox button {
-        display: block;
-        width: 80px;
-        margin: 0 auto;
-    }
-
-    .hidden {
-        display: none;
-    }
-</style>
 <body>
-<div class="wrapper" >
-    <div class = "content" style="text-align : center;">
-        <img src="img/aaaakkkbo.png"/>
+    <div id="wrapper">
+        <img src="img/logo.png"/>
         <p>
             위 질문을 등록하면, 관리자가 답변 후 적어주신 연락처로 답변을 드립니다.
         </p>
         <p>
-            더 빠른 답변을 원하시면 동국대학교 입학처 02-2260-8861 으로 연락주시면 됩니다
+            더 빠른 답변을 원하시면 동국대학교 입학처 02-2260-8861 으로 연락주시면
+            됩니다
         </p>
         <p>여러분의 합격을 응원합니다!</p>
-        <!--form method="post" action="/add"-->
-            <!--액션 설정해줄것-->
-            <div class = "content" style="text-align : left;">
-            <label for="Name">이     름 : </label>
-            <input type="text" name="name" id="Name"/>
-            <br><br>
-            <label for="Phone">전화번호 : </label>
-            <input type="text" name="phone" id="Phone"/>
-            <br><br>
-            <label for="Question">질문</label><br>
-            <textarea name="content" rows="10" cols="100" id="Question"></textarea>
-            <br>
-                <button class="openBtn">제출</button>
-                <div class="modal hidden">
-                    <div class="bg"></div>
-                    <div class="modalBox">
-                        <div class ="modal-header">
-                            <p style="font-size:24px">정말로 제출 하시겠습니까?<br><hr color="#DCDCDC"/></p>
-                            <div class = "modal-body">제출하시려면 "확인"버튼을 누르십시오</div>
-                            <br><br>
-                            <div class = "modal-footer">
-                                <button type="button" style="float:left" onClick="location
-                                .href='dongguk'">확인</button>
-                                <button class="closeBtn" style="float:left">취소</button>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-
-                <script>
-                    const open = () => {
-                        document.querySelector(".modal").classList.remove("hidden");
-                    }
-
-                    const close = () => {
-                        document.querySelector(".modal").classList.add("hidden");
-                    }
-
-                    document.querySelector(".openBtn").addEventListener("click", open);
-                    document.querySelector(".closeBtn").addEventListener("click", close);
-                    document.querySelector(".bg").addEventListener("click", close);
-
-                </script>
-            </div>
-        </div>
     </div>
-</div>
+    <div id="question-area">
+        <form method="post" action="/add">
+            <!--액션 설정해줄것-->
+            <label for="Name">Name:</label>
+            <input type="text" name="name" id="Name"/>
+
+            <label for="Phone">Phone:</label>
+            <input type="text" name="phone" id="Phone"/>
+
+            <label for="Question">Question:</label><br/>
+            <textarea name="content" rows="20" cols="20" id="Question"></textarea>
+
+            <input
+                    type="submit"
+                    name="submit"
+                    value="Submit"
+                    class="submit-button"
+            />
+        </form>
+    </div>
 </body>
 </html>

--- a/src/main/resources/templates/common_codes/sidebar.html
+++ b/src/main/resources/templates/common_codes/sidebar.html
@@ -20,7 +20,12 @@
             <i class="fas fa-fw fa-tachometer-alt"></i>
             <span>질문게시판</span></a>
     </li>
-
+    <li class="nav-item">
+        <!-- TODO 0503-->
+        <a class="nav-link" href="manage"> <!--질문페이지로 이동 -->
+            <i class="fas fa-fw fa-tachometer-alt"></i>
+            <span>아코봇 데이터베이스 관리</span></a>
+    </li>
     <!-- Divider -->
     <!--hr class="sidebar-divider"-->
 

--- a/src/main/resources/templates/common_codes/topbar.html
+++ b/src/main/resources/templates/common_codes/topbar.html
@@ -33,7 +33,7 @@
         <!-- Nav Item - User Information -->
         <!-- TODO 차후 유저에 맞게 변화될 수 있도록 0503-->
         <li class="nav-item dropdown no-arrow">
-            <a class="nav-link dropdown-toggle" href="#" id="userDropdown" role="button"
+            <a class="nav-link dropdown-toggle" href="" id="userDropdown" role="button"
                data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                 <!--img class = 'img-profile square' src="img/Calen.png" hspace = 30-->
                 <img class="img-profile rounded-circle" src="img/Person.png" width = "100" height="100">
@@ -41,10 +41,25 @@
             <!-- Dropdown - User Information -->
             <div class="dropdown-menu dropdown-menu-right shadow animated--grow-in"
                  aria-labelledby="userDropdown">
-                <a class="dropdown-item" href="#" data-toggle="modal" data-target="#logoutModal">
+                <!-- 로그인 -->
+                <div class="row">
+                    <div class="col-md-10">
+                        <div th:if="${not #strings.isEmpty(userName)}">
+                            <img style="width:45px; height:45px" src="" th:src="${userImg}"
+                                 class="rounded-circle img-thumbnail img-responsive">
+                            <span id="login-user" th:text="${userName}">사용자</span> 님, 안녕하세요.
+                            <a href="/logout" class="btn btn-sm btn-info active" role="button">Logout</a>
+                        </div>
+                        <div th:if="${#strings.isEmpty(userName)}">
+                            <!-- 스프링 시큐리티에서 기본 제공하는 URL - 별도 컨트롤러 작성 필요 없음 -->
+                            <a href="/oauth2/authorization/google" role="button">로그인 하기</a>
+                        </div>
+                    </div>
+                </div>
+                <!--<a class="dropdown-item" href="#" data-toggle="modal" data-target="#logoutModal">
                     <i class="fas fa-sign-out-alt fa-sm fa-fw mr-2 text-gray-400"></i>
                     로그아웃
-                </a>
+                </a>-->
                 <a class = "dropdown-item">
                     <input id="changeDark" type="button" value="DarkMode" onclick="
         if(document.querySelector('#changeDark').value === 'DarkMode'){ // 지금 상태가 light 모드 , Dark로 바꾸려면

--- a/src/main/resources/templates/manage.html
+++ b/src/main/resources/templates/manage.html
@@ -1,0 +1,157 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th= "http://www.thymeleaf.org">
+<head th:replace="common_codes/fragments.html:: fragment-header(title='SB Admin 2 - tables')"></head>
+<body id="page-top">
+
+<!-- Page Wrapper -->
+<div id="wrapper">
+
+    <!-- Sidebar -->
+    <th:block th:replace="~{/common_codes/sidebar.html}"></th:block>
+    <!-- End of Sidebar -->
+
+    <!-- Content Wrapper -->
+    <div id="content-wrapper" class="d-flex flex-column">
+
+        <!-- Main Content -->
+        <div id="content">
+
+            <!-- Topbar -->
+            <th:block th:replace="~{/common_codes/topbar.html}"></th:block>
+            <!-- End of Topbar -->
+
+            <!-- Begin Page Content -->
+            <div class="container-fluid">
+                <div class="treeview-animated w-20 border mx-4 my-4">
+                    <h6 class="pt-3 pl-3">아코봇 DB 구조</h6>
+                    <hr>
+                    <ul class="treeview-animated-list mb-3">
+                        <li class="treeview-animated-items">
+                            <a class="closed">
+                                <i class="fas fa-angle-right"></i>
+                                <span><i class="far fa-envelope-open ic-w mx-1"></i>Mail</span>
+                            </a>
+                            <ul class="nested">
+                                <li>
+                                    <div class="treeview-animated-element"><i class="far fa-bell ic-w mr-1"></i>Offers
+                                </li>
+                                <li>
+                                    <div class="treeview-animated-element"><i class="far fa-address-book ic-w mr-1"></i>Contacts
+                                </li>
+                                <li class="treeview-animated-items">
+                                    <a class="closed"><i class="fas fa-angle-right"></i>
+                                        <span><i class="far fa-calendar-alt ic-w mx-1"></i>Calendar</span></a>
+                                    <ul class="nested">
+                                        <li>
+                                            <div class="treeview-animated-element"><i class="far fa-clock ic-w mr-1"></i>Deadlines
+                                        </li>
+                                        <li>
+                                            <div class="treeview-animated-element"><i class="fas fa-users ic-w mr-1"></i>Meetings
+                                        </li>
+                                        <li>
+                                            <div class="treeview-animated-element"><i class="fas fa-basketball-ball ic-w mr-1"></i>Workouts
+                                        </li>
+                                        <li>
+                                            <div class="treeview-animated-element"><i class="fas fa-mug-hot ic-w mr-1"></i>Events
+                                        </li>
+                                    </ul>
+                                </li>
+                            </ul>
+                        </li>
+                        <li class="treeview-animated-items">
+                            <a class="closed">
+                                <i class="fas fa-angle-right"></i>
+                                <span><i class="far fa-folder-open ic-w mx-1"></i>Inbox</span>
+                            </a>
+                            <ul class="nested">
+                                <li>
+                                    <div class="treeview-animated-element"><i class="far fa-folder-open ic-w mr-1"></i>Admin
+                                </li>
+                                <li>
+                                    <div class="treeview-animated-element"><i class="far fa-folder-open ic-w mr-1"></i>Corporate
+                                </li>
+                                <li>
+                                    <div class="treeview-animated-element"><i class="far fa-folder-open ic-w mr-1"></i>Finance
+                                </li>
+                                <li>
+                                    <div class="treeview-animated-element"><i class="far fa-folder-open ic-w mr-1"></i>Other
+                                </li>
+                            </ul>
+                        </li>
+                        <li class="treeview-animated-items">
+                            <a class="closed">
+                                <i class="fas fa-angle-right"></i>
+                                <span><i class="far fa-gem mx-1"></i>Favourites</span>
+                            </a>
+                            <ul class="nested">
+                                <li>
+                                    <div class="treeview-animated-element"><i class="fas fa-pepper-hot ic-w mr-1"></i>Restaurants
+                                </li>
+                                <li>
+                                    <div class="treeview-animated-element"><i class="far fa-eye ic-w mr-1"></i>Places
+                                </li>
+                                <li>
+                                    <div class="treeview-animated-element"><i class="fas fa-gamepad ic-w mr-1"></i>Games
+                                </li>
+                                <li>
+                                    <div class="treeview-animated-element"><i class="fas fa-cocktail ic-w mr-1"></i>Coctails
+                                </li>
+                                <li>
+                                    <div class="treeview-animated-element"><i class="fas fa-pizza-slice ic-w mr-1"></i>Food
+                                </li>
+                            </ul>
+                        </li>
+                        <li>
+                            <div class="treeview-animated-element"><i class="far fa-comment ic-w mr-1"></i>Notes
+                        </li>
+                        <li>
+                            <div class="treeview-animated-element"><i class="fas fa-cogs ic-w mr-1"></i>Settings
+                        </li>
+                        <li>
+                            <div class="treeview-animated-element"><i class="fas fa-desktop ic-w mr-1"></i>Devices
+                        </li>
+                        <li>
+                            <div class="treeview-animated-element"><i class="fas fa-trash-alt ic-w mr-1"></i>Deleted Items
+                        </li>
+                    </ul>
+                </div>
+
+                <script>
+                    // Treeview Initialization
+                    $(document).ready(function () {
+                        $('.treeview').mdbTreeview();
+                    });
+                </script>
+
+
+
+            </div>
+            <!-- /.container-fluid -->
+
+        </div>
+        <!-- End of Main Content -->
+
+        <!-- Footer -->
+        <th:block th:replace="~{/common_codes/footer.html}"></th:block>
+        <!-- End of Footer -->
+
+    </div>
+    <!-- End of Content Wrapper -->
+
+</div>
+<!-- End of Page Wrapper -->
+
+<!-- Scroll to Top Button-->
+<a class="scroll-to-top rounded" href="#page-top">
+    <i class="fas fa-angle-up"></i>
+</a>
+
+<!-- Logout Modal-->
+<th:block th:replace="~{/common_codes/logout_modal.html}"></th:block>
+
+<!-- footer를 그대로 inlcude-->
+<footer th:replace="common_codes/fragments.html :: footer"></footer>
+
+</body>
+
+</html>

--- a/src/test/java/com/AkobotWeb/AkobotWebApplicationTests.java
+++ b/src/test/java/com/AkobotWeb/AkobotWebApplicationTests.java
@@ -3,11 +3,20 @@ package com.AkobotWeb;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
+import java.time.LocalDateTime;
+
 @SpringBootTest
 class AkobotWebApplicationTests {
 
 	@Test
 	void contextLoads() {
+	}
+
+	/* JPA Auditing 테스트 코드 */
+	@Test
+	public void baseTimeEntity_test(){
+		//given
+		LocalDateTime now = LocalDateTime.of(2021,05,25,0,0,0);
 	}
 
 }


### PR DESCRIPTION
### 개요
좀 더 관리자 페이지의 기능 구현에 충실하고 싶어서 
일단 로그인 부분은 스프링 시큐리티 와 구글 로그인 연동을 함.
<strong>:star 중요</strong>resource 폴더에 `application-oauth.properties` 를 추가해야함.


##### [구현 모습]
---
상단의 사람 모양 이미지를 누르면 다음의 화면이 나와서 구글 로그인을 할 수 있게 함.
![구글 로그인0](https://user-images.githubusercontent.com/54317409/119430751-4bb13180-bd4c-11eb-9479-8528a16676cc.JPG)

로그인 되었을 때 모습
![구글 로그인1](https://user-images.githubusercontent.com/54317409/119430827-6a172d00-bd4c-11eb-9875-a8e3b6cc829d.JPG)


##### [구현 내용]
---
1. `build.gradle` 에 관련 의존성을 추가함


2. 구글 클라우드 프로젝트에서 OAuth2 로그인을 지원하도록 개인 개정에 대한 정보를 담은  application-oauth.properties를 작성함 
 이는 .gitignore에 등록됨

3.  스프링 시큐리티는 사용자 권한을 명시해야므로 관련 `Role` 이라는 Enum 클래스를 작성함

4. JPA 의 `Entity` 어노테이션을 이용하는 domain 패키지의 User 클래스를 생성함

5. OAuthAttributes 클래스를 작성함. 구글 로그인 이후 사용자의 이메일 이름, 프로필 사진 등을 저장하는 `Data Transfer Object`

6. 가입 및 정보 수정, 세션 저장 기능을 위해 `CustomOAuth2UserService` 클래스를 작성

7. 스프링 시큐리티 설정을 위한 `SecurityConfig` 클래스 작성. 
   ( URL 별 권환 관리 설정권환 관리 대상을 지정하는 옵션, 로그아웃 기능에 대한 진입점, 성공시 /주소로 이동 //OAuth2 로그인 
     성공 이후 사용자 정보를 가져올 때의 설정 등을 다룸)
![허용 url](https://user-images.githubusercontent.com/54317409/119430861-77341c00-bd4c-11eb-93ba-ba6a4297a004.JPG)



8. 유저의 세션정보를 위한 `SessionUser` 클래스 작성
9. `MainController` 에서 각 페이지에 세션 정보를 받을 수 있게 함.
      목적 > 이는 `Topbar.html`에서 로그인 세션이 연동되는 효과를 기대할 수 있음. 
      단점 > 코드의 중복이 조금 있어서 고쳐보려했으나 Null Exception이 발생함. 


10. 아코봇 DB의 구조를 관리자에게 명시적으로 보여주고 싶어서 관련 트리 구조를 출력하는 예제 템플릿을 이용함.
 컬렉션 - 도큐먼트 순으로 트리 구조를 출력하면 좋을 것 같음.
![아코봇 db확인](https://user-images.githubusercontent.com/54317409/119430873-7e5b2a00-bd4c-11eb-98b9-395c5c01f6af.JPG)



